### PR TITLE
Fixed syntax to make it work with a different user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     repo: "{{ repository }}"
     dest: "{{ user_home }}/.bash_it"
     version: "{{ version }}"
-  become: "{{ user }}"
+  become_user: "{{ user }}"
 
 - name: .bash_profile loads .bashrc for {{ user }}
   blockinfile:


### PR DESCRIPTION
Syntax for become is not correct, so if you run this role as a different user it will not work. Line 20 should be as per below:
  become_user: "{{ user }}"