### PR TITLE
Added `bashrc_install` boolean variable to disable `~/.bashrc` changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .kitchen/
+.idea/
 Gemfile.lock
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ Usage
 Include the role, and specify the user you want to install the bash-it for.
 Note: The role will change the default shell for the user to be `/bin/bash`.
 
-| Variable    | Default value                          | Description                      |
-|-------------|----------------------------------------|----------------------------------|
-| user        | {{ ansible_user_id }}                  | User to install bash-it for      |
-| theme       | pure                                   | Bash-it Theme to install         |
-| aliases     | []                                     | A list of aliases to install     |
-| plugins     | []                                     | A list of plugins to install     |
-| completions | []                                     | A list of completions to install |
-| repository  | https://github.com/bash-it/bash-it.git | Git repository for the bash-it   |
-| version     | master                                 | Git version tag to retrieve      |
+| Variable       | Default value                          | Description                                |
+|----------------|----------------------------------------|--------------------------------------------|
+| user           | {{ ansible_user_id }}                  | User to install bash-it for                |
+| theme          | pure                                   | Bash-it Theme to install                   |
+| aliases        | []                                     | A list of aliases to install               |
+| plugins        | []                                     | A list of plugins to install               |
+| completions    | []                                     | A list of completions to install           |
+| repository     | https://github.com/bash-it/bash-it.git | Git repository for the bash-it             |
+| version        | master                                 | Git version tag to retrieve                |
+| bashrc_install | true                                   | Update .bashrc to source bash_it.sh or not |
+
+If you have wish to update `~/.bashrc` yourself rather than have this role
+add code to source `bash_it.sh`, set the `bashrc_install` variable to `false`.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ completions:
   - bash-it
   - system
 user: "{{ ansible_user_id }}"
+bashrc_install: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     - { regexp: '^export BASH_IT=', line: 'export BASH_IT="$HOME/.bash_it"' }
     - { regexp: '^export BASH_IT_THEME=', line: 'export BASH_IT_THEME={{ theme }}' }
     - { regexp: '^source \$BASH_IT', line: 'source $BASH_IT/bash_it.sh' }
+  when: bashrc_install
 
 - name: install bash_it plugins for {{ user }}
   command: "/bin/bash -i -l -c \"bash-it enable plugin {{ plugins|join(' ') }}\""


### PR DESCRIPTION
* Added `bashrc_install: true` to `defaults/main.yml`
* Updated `install bash_it on .bashrc for {{ user }}` step to execute when `bashrc_install` is `true`
* Added JetBrains' `./idea` IDE folders to `.gitignore`
* Updated `README.md` to document `bashrc_isntall` variable

For folks who have tasks or roles that run after `ansible-bash_it` that update `~/.bashrc` themselves and don't want this role's modifications to cause that file to appear modified every run.